### PR TITLE
Implement fastapi-users authentication

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
+    "aiosqlite>=0.20.0",
     "ruff>=0.8.0",
     "pyright>=1.1.390",
 ]

--- a/apps/api/src/wintern/auth/dependencies.py
+++ b/apps/api/src/wintern/auth/dependencies.py
@@ -1,0 +1,15 @@
+"""Authentication dependencies for use in route handlers."""
+
+from wintern.auth.service import fastapi_users
+
+# Dependency to get the current active user
+current_user = fastapi_users.current_user(active=True)
+
+# Dependency to get the current active verified user
+current_verified_user = fastapi_users.current_user(active=True, verified=True)
+
+# Dependency to get the current superuser
+current_superuser = fastapi_users.current_user(active=True, superuser=True)
+
+# Optional current user (returns None if not authenticated)
+optional_current_user = fastapi_users.current_user(active=True, optional=True)

--- a/apps/api/src/wintern/auth/router.py
+++ b/apps/api/src/wintern/auth/router.py
@@ -1,0 +1,55 @@
+"""Authentication routes."""
+
+from fastapi import APIRouter
+
+from wintern.auth.schemas import UserCreate, UserRead, UserUpdate
+from wintern.auth.service import (
+    fastapi_users,
+    google_oauth_client,
+    jwt_backend,
+)
+from wintern.core.config import settings
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# Register and login routes
+router.include_router(
+    fastapi_users.get_auth_router(jwt_backend),
+    prefix="",
+)
+
+# Registration route
+router.include_router(
+    fastapi_users.get_register_router(UserRead, UserCreate),
+    prefix="",
+)
+
+# Password reset routes
+router.include_router(
+    fastapi_users.get_reset_password_router(),
+    prefix="",
+)
+
+# Email verification routes
+router.include_router(
+    fastapi_users.get_verify_router(UserRead),
+    prefix="",
+)
+
+# User management routes (me endpoint)
+router.include_router(
+    fastapi_users.get_users_router(UserRead, UserUpdate),
+    prefix="/users",
+)
+
+# Google OAuth routes (only if configured)
+if settings.google_oauth_client_id and settings.google_oauth_client_secret:
+    router.include_router(
+        fastapi_users.get_oauth_router(
+            google_oauth_client,
+            jwt_backend,
+            settings.secret_key,
+            associate_by_email=True,
+        ),
+        prefix="/google",
+    )

--- a/apps/api/src/wintern/auth/schemas.py
+++ b/apps/api/src/wintern/auth/schemas.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for authentication."""
+
+import uuid
+
+from fastapi_users import schemas
+
+
+class UserRead(schemas.BaseUser[uuid.UUID]):
+    """Schema for reading user data."""
+
+    pass
+
+
+class UserCreate(schemas.BaseUserCreate):
+    """Schema for creating a new user."""
+
+    pass
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    """Schema for updating user data."""
+
+    pass

--- a/apps/api/src/wintern/auth/service.py
+++ b/apps/api/src/wintern/auth/service.py
@@ -1,0 +1,121 @@
+"""FastAPI Users configuration and service setup."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Annotated
+
+import structlog
+from fastapi import Depends, Request
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin
+from fastapi_users.authentication import (
+    AuthenticationBackend,
+    BearerTransport,
+    JWTStrategy,
+)
+from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
+from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyAccessTokenDatabase
+from httpx_oauth.clients.google import GoogleOAuth2
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from wintern.auth.models import AccessToken, OAuthAccount, User
+from wintern.core.config import settings
+from wintern.core.database import async_session
+
+log = structlog.get_logger()
+
+
+# Google OAuth client
+google_oauth_client = GoogleOAuth2(
+    client_id=settings.google_oauth_client_id,
+    client_secret=settings.google_oauth_client_secret,
+)
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    """Get an async database session."""
+    async with async_session() as session:
+        yield session
+
+
+AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_session)]
+
+
+async def get_user_db(
+    session: AsyncSessionDep,
+) -> AsyncGenerator[SQLAlchemyUserDatabase, None]:
+    """Get the user database adapter."""
+    yield SQLAlchemyUserDatabase(session, User, OAuthAccount)
+
+
+UserDbDep = Annotated[SQLAlchemyUserDatabase, Depends(get_user_db)]
+
+
+async def get_access_token_db(
+    session: AsyncSessionDep,
+) -> AsyncGenerator[SQLAlchemyAccessTokenDatabase, None]:
+    """Get the access token database adapter."""
+    yield SQLAlchemyAccessTokenDatabase(session, AccessToken)
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    """User manager with custom logic for user lifecycle events."""
+
+    reset_password_token_secret = settings.secret_key
+    verification_token_secret = settings.secret_key
+
+    async def on_after_register(self, user: User, request: Request | None = None):
+        """Called after a user registers."""
+        log.info("User registered", user_id=str(user.id), email=user.email)
+
+    async def on_after_forgot_password(
+        self, user: User, token: str, request: Request | None = None
+    ):
+        """Called after a user requests a password reset."""
+        log.info(
+            "Password reset requested",
+            user_id=str(user.id),
+            email=user.email,
+        )
+
+    async def on_after_request_verify(
+        self, user: User, token: str, request: Request | None = None
+    ):
+        """Called after a user requests email verification."""
+        log.info(
+            "Verification requested",
+            user_id=str(user.id),
+            email=user.email,
+        )
+
+
+async def get_user_manager(
+    user_db: UserDbDep,
+) -> AsyncGenerator[UserManager, None]:
+    """Get the user manager instance."""
+    yield UserManager(user_db)
+
+
+# JWT Authentication
+bearer_transport = BearerTransport(tokenUrl="auth/login")
+
+
+def get_jwt_strategy() -> JWTStrategy:
+    """Get the JWT strategy for authentication."""
+    return JWTStrategy(
+        secret=settings.secret_key,
+        lifetime_seconds=settings.access_token_expire_minutes * 60,
+    )
+
+
+jwt_backend = AuthenticationBackend(
+    name="jwt",
+    transport=bearer_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+
+# FastAPIUsers instance
+fastapi_users = FastAPIUsers[User, uuid.UUID](
+    get_user_manager,
+    [jwt_backend],
+)

--- a/apps/api/src/wintern/core/config.py
+++ b/apps/api/src/wintern/core/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     secret_key: str = "change-me-in-production"
     access_token_expire_minutes: int = 30
 
+    # Google OAuth
+    google_oauth_client_id: str = ""
+    google_oauth_client_secret: str = ""
+
     # OpenRouter
     openrouter_api_key: str = ""
     default_model: str = "anthropic/claude-sonnet-4-20250514"

--- a/apps/api/src/wintern/main.py
+++ b/apps/api/src/wintern/main.py
@@ -7,6 +7,7 @@ import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from wintern.auth.router import router as auth_router
 from wintern.core.config import settings
 
 log = structlog.get_logger()
@@ -34,6 +35,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Include routers
+app.include_router(auth_router)
 
 
 @app.get("/health")

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Pytest configuration and fixtures."""
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from wintern.auth.service import get_async_session
+from wintern.core.database import Base
+from wintern.main import app
+
+# Use in-memory SQLite for tests
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an event loop for the test session."""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture
+async def test_engine():
+    """Create a test database engine."""
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def test_session(test_engine) -> AsyncGenerator[AsyncSession, None]:
+    """Create a test database session."""
+    async_session_maker = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+    async with async_session_maker() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def client(test_engine) -> AsyncGenerator[AsyncClient, None]:
+    """Create an async test client with test database."""
+    async_session_maker = async_sessionmaker(
+        test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async def get_test_session() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_maker() as session:
+            yield session
+
+    # Override the session dependency
+    app.dependency_overrides[get_async_session] = get_test_session
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -1,0 +1,149 @@
+"""Tests for authentication endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_register_user(client: AsyncClient):
+    """Test user registration."""
+    response = await client.post(
+        "/auth/register",
+        json={
+            "email": "test@example.com",
+            "password": "testpassword123",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "test@example.com"
+    assert "id" in data
+    assert "hashed_password" not in data
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_email(client: AsyncClient):
+    """Test registration with duplicate email fails."""
+    # Register first user
+    await client.post(
+        "/auth/register",
+        json={
+            "email": "duplicate@example.com",
+            "password": "testpassword123",
+        },
+    )
+
+    # Try to register with same email
+    response = await client.post(
+        "/auth/register",
+        json={
+            "email": "duplicate@example.com",
+            "password": "anotherpassword",
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_login(client: AsyncClient):
+    """Test user login returns JWT token."""
+    # First register a user
+    await client.post(
+        "/auth/register",
+        json={
+            "email": "login@example.com",
+            "password": "testpassword123",
+        },
+    )
+
+    # Login
+    response = await client.post(
+        "/auth/login",
+        data={
+            "username": "login@example.com",
+            "password": "testpassword123",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_login_invalid_credentials(client: AsyncClient):
+    """Test login with invalid credentials fails."""
+    response = await client.post(
+        "/auth/login",
+        data={
+            "username": "nonexistent@example.com",
+            "password": "wrongpassword",
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_current_user(client: AsyncClient):
+    """Test getting current user with valid token."""
+    # Register and login
+    await client.post(
+        "/auth/register",
+        json={
+            "email": "me@example.com",
+            "password": "testpassword123",
+        },
+    )
+    login_response = await client.post(
+        "/auth/login",
+        data={
+            "username": "me@example.com",
+            "password": "testpassword123",
+        },
+    )
+    token = login_response.json()["access_token"]
+
+    # Get current user
+    response = await client.get(
+        "/auth/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "me@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_unauthorized(client: AsyncClient):
+    """Test getting current user without token fails."""
+    response = await client.get("/auth/users/me")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_logout(client: AsyncClient):
+    """Test logout endpoint."""
+    # Register and login
+    await client.post(
+        "/auth/register",
+        json={
+            "email": "logout@example.com",
+            "password": "testpassword123",
+        },
+    )
+    login_response = await client.post(
+        "/auth/login",
+        data={
+            "username": "logout@example.com",
+            "password": "testpassword123",
+        },
+    )
+    token = login_response.json()["access_token"]
+
+    # Logout
+    response = await client.post(
+        "/auth/logout",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # JWT logout typically returns 204 or 200
+    assert response.status_code in [200, 204]

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -126,6 +126,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3617,6 +3626,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -3626,6 +3636,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "apscheduler", specifier = ">=3.10.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary
- Implements JWT-based authentication using fastapi-users
- Adds Google OAuth support (configurable via environment variables)
- Creates auth service with UserManager, schemas, and dependencies
- Adds comprehensive test suite with async fixtures

Closes #7

## Changes
- `core/config.py`: Add Google OAuth client settings
- `auth/schemas.py`: UserRead, UserCreate, UserUpdate Pydantic schemas
- `auth/service.py`: FastAPIUsers configuration, UserManager, JWT backend
- `auth/dependencies.py`: current_user, current_superuser dependencies
- `auth/router.py`: Consolidated auth routes
- `main.py`: Mount auth router
- `tests/conftest.py`: Async test fixtures with in-memory SQLite
- `tests/test_auth.py`: Registration, login, logout, protected route tests

## Auth Routes
- `POST /auth/register` - Email registration
- `POST /auth/login` - JWT login (returns bearer token)
- `POST /auth/logout` - Logout
- `GET /auth/users/me` - Get current user (protected)
- `PATCH /auth/users/me` - Update current user
- `POST /auth/forgot-password` - Request password reset
- `POST /auth/reset-password` - Reset password
- `POST /auth/request-verify-token` - Request email verification
- `POST /auth/verify` - Verify email
- `GET /auth/google/authorize` - Google OAuth start (if configured)
- `GET /auth/google/callback` - Google OAuth callback (if configured)

## Test plan
- [x] All 8 tests pass locally
- [x] Ruff linting passes
- [x] Pyright type checking passes
- [x] Manual testing with `POST /auth/register` and `POST /auth/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)