### PR TITLE
Fix Dependabot config for pnpm monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
       - dependencies
       - python
 
-  # Node dependencies for Web
+  # Node dependencies (pnpm monorepo - must point to root for lockfile)
   - package-ecosystem: npm
-    directory: /apps/web
+    directory: /
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary
- Point npm ecosystem to root directory (`/`) where `pnpm-lock.yaml` lives
- Previously pointed to `/apps/web` which caused lockfile mismatch errors

## Problem
Dependabot was updating `apps/web/package.json` but not the root `pnpm-lock.yaml`, causing CI failures with `ERR_PNPM_OUTDATED_LOCKFILE`.

## Test plan
- [x] Config syntax is valid
- [ ] After merge, close stale Dependabot PRs (#39-43)
- [ ] Verify new Dependabot PRs properly update lockfile

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)