### PR TITLE
feat: implement Reddit data source integration

### DIFF
--- a/apps/api/src/wintern/sources/__init__.py
+++ b/apps/api/src/wintern/sources/__init__.py
@@ -11,6 +11,18 @@ from wintern.sources.brave import (
     brave_search,
     search_brave,
 )
+from wintern.sources.reddit import (
+    RedditAPIError,
+    RedditAuthError,
+    RedditClient,
+    RedditCredentialsMissingError,
+    RedditError,
+    RedditRateLimitError,
+    RedditSource,
+    TimeFilter,
+    reddit_source,
+    search_reddit,
+)
 from wintern.sources.schemas import SearchResult
 
 __all__ = [
@@ -21,7 +33,17 @@ __all__ = [
     "BraveSearchSource",
     "DataSource",
     "FreshnessFilter",
+    "RedditAPIError",
+    "RedditAuthError",
+    "RedditClient",
+    "RedditCredentialsMissingError",
+    "RedditError",
+    "RedditRateLimitError",
+    "RedditSource",
     "SearchResult",
+    "TimeFilter",
     "brave_search",
+    "reddit_source",
     "search_brave",
+    "search_reddit",
 ]

--- a/apps/api/src/wintern/sources/reddit.py
+++ b/apps/api/src/wintern/sources/reddit.py
@@ -1,0 +1,439 @@
+"""Reddit API integration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+import httpx
+
+from wintern.core.config import settings
+from wintern.sources.base import DataSource
+from wintern.sources.schemas import SearchResult
+
+logger = logging.getLogger(__name__)
+
+# Reddit API endpoints
+REDDIT_AUTH_URL = "https://www.reddit.com/api/v1/access_token"
+REDDIT_SEARCH_URL = "https://oauth.reddit.com/search"
+REDDIT_SUBREDDIT_SEARCH_URL = "https://oauth.reddit.com/r/{subreddit}/search"
+
+# Rate limiting state (Reddit allows 60 requests/minute)
+_rate_limit_semaphore = asyncio.Semaphore(1)
+_last_request_time: float = 0.0
+_MIN_REQUEST_INTERVAL: float = 1.0  # 1 request per second = 60/minute
+
+
+# Time filter options
+TimeFilter = Literal["hour", "day", "week", "month", "year", "all"]
+
+
+class RedditError(Exception):
+    """Base exception for Reddit errors."""
+
+    pass
+
+
+class RedditCredentialsMissingError(RedditError):
+    """Raised when Reddit credentials are not configured."""
+
+    pass
+
+
+class RedditAuthError(RedditError):
+    """Raised when authentication fails."""
+
+    pass
+
+
+class RedditRateLimitError(RedditError):
+    """Raised when rate limited by Reddit API."""
+
+    pass
+
+
+class RedditAPIError(RedditError):
+    """Raised for general Reddit API errors."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        super().__init__(f"Reddit API error ({status_code}): {message}")
+
+
+def _parse_created_utc(timestamp: float | None) -> datetime | None:
+    """Parse Reddit's created_utc timestamp into a UTC datetime.
+
+    Args:
+        timestamp: Unix timestamp from Reddit API.
+
+    Returns:
+        A UTC-aware datetime object or None if parsing fails.
+    """
+    if timestamp is None:
+        return None
+
+    try:
+        return datetime.fromtimestamp(timestamp, tz=UTC)
+    except (ValueError, OSError, OverflowError):
+        return None
+
+
+async def _rate_limit() -> None:
+    """Enforce rate limiting between requests."""
+    global _last_request_time
+
+    async with _rate_limit_semaphore:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        time_since_last = now - _last_request_time
+
+        if time_since_last < _MIN_REQUEST_INTERVAL:
+            await asyncio.sleep(_MIN_REQUEST_INTERVAL - time_since_last)
+
+        _last_request_time = loop.time()
+
+
+class RedditClient:
+    """Reddit API client with OAuth2 authentication."""
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        user_agent: str,
+    ) -> None:
+        """Initialize the Reddit client.
+
+        Args:
+            client_id: Reddit OAuth client ID.
+            client_secret: Reddit OAuth client secret.
+            user_agent: User agent string for API requests.
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.user_agent = user_agent
+        self._token: str | None = None
+        self._token_expires: datetime | None = None
+
+    async def _get_token(self, timeout: float = 30.0) -> str:
+        """Get a valid access token, refreshing if necessary.
+
+        Args:
+            timeout: Request timeout in seconds.
+
+        Returns:
+            A valid access token.
+
+        Raises:
+            RedditAuthError: If authentication fails.
+        """
+        now = datetime.now(UTC)
+
+        # Return cached token if still valid
+        if self._token and self._token_expires and now < self._token_expires:
+            return self._token
+
+        # Request new token
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(
+                    REDDIT_AUTH_URL,
+                    auth=(self.client_id, self.client_secret),
+                    data={"grant_type": "client_credentials"},
+                    headers={"User-Agent": self.user_agent},
+                )
+
+                if response.status_code == 401:
+                    raise RedditAuthError("Invalid Reddit credentials")
+
+                response.raise_for_status()
+                data = response.json()
+
+                token: str = data["access_token"]
+                self._token = token
+                # Refresh 60 seconds before expiry
+                expires_in = data.get("expires_in", 3600)
+                self._token_expires = now + timedelta(seconds=expires_in - 60)
+
+                logger.debug("Reddit OAuth token refreshed")
+                return token
+
+        except httpx.HTTPStatusError as e:
+            raise RedditAuthError(f"Authentication failed: {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise RedditAuthError(f"Authentication request failed: {e}") from e
+
+    def clear_token(self) -> None:
+        """Clear the cached token, forcing re-authentication."""
+        self._token = None
+        self._token_expires = None
+
+
+async def search_reddit(
+    query: str,
+    *,
+    subreddits: list[str] | None = None,
+    time_filter: TimeFilter = "week",
+    count: int = 25,
+    max_retries: int = 3,
+    timeout: float = 30.0,
+    client: RedditClient | None = None,
+) -> list[SearchResult]:
+    """Search Reddit for posts matching the query.
+
+    Args:
+        query: The search query string.
+        subreddits: List of subreddits to search in (None for all Reddit).
+        time_filter: Time filter for results:
+            - "hour": Past hour
+            - "day": Past 24 hours
+            - "week": Past week
+            - "month": Past month
+            - "year": Past year
+            - "all": All time
+        count: Maximum number of results to return (1-100).
+        max_retries: Maximum number of retry attempts for transient errors.
+        timeout: Request timeout in seconds.
+        client: Optional pre-configured RedditClient instance.
+
+    Returns:
+        A list of SearchResult objects.
+
+    Raises:
+        RedditCredentialsMissingError: If Reddit credentials are not configured.
+        RedditAuthError: If authentication fails.
+        RedditRateLimitError: If rate limited after retries.
+        RedditAPIError: For other API errors.
+    """
+    # Check credentials
+    if not settings.reddit_client_id or not settings.reddit_client_secret:
+        raise RedditCredentialsMissingError(
+            "REDDIT_CLIENT_ID and REDDIT_CLIENT_SECRET environment variables must be set"
+        )
+
+    # Use provided client or create one
+    if client is None:
+        client = RedditClient(
+            client_id=settings.reddit_client_id,
+            client_secret=settings.reddit_client_secret,
+            user_agent=settings.reddit_user_agent,
+        )
+
+    # Clamp count to valid range
+    count = max(1, min(100, count))
+
+    # Build search URL
+    if subreddits:
+        # Search within specific subreddits
+        subreddit_str = "+".join(subreddits)
+        url = REDDIT_SUBREDDIT_SEARCH_URL.format(subreddit=subreddit_str)
+    else:
+        url = REDDIT_SEARCH_URL
+
+    params: dict[str, str | int] = {
+        "q": query,
+        "limit": count,
+        "t": time_filter,
+        "sort": "relevance",
+        "type": "link",  # Only search posts, not comments
+    }
+
+    last_error: Exception | None = None
+
+    for attempt in range(max_retries):
+        try:
+            await _rate_limit()
+
+            token = await client._get_token(timeout=timeout)
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "User-Agent": client.user_agent,
+            }
+
+            async with httpx.AsyncClient(timeout=timeout) as http_client:
+                response = await http_client.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                )
+
+                if response.status_code == 401:
+                    # Token might have expired, clear and retry
+                    client.clear_token()
+                    last_error = RedditAuthError("Token expired")
+                    continue
+
+                if response.status_code == 429:
+                    # Rate limited
+                    retry_after = int(response.headers.get("Retry-After", "60"))
+                    logger.warning(
+                        f"Reddit API rate limited, waiting {retry_after}s "
+                        f"(attempt {attempt + 1}/{max_retries})"
+                    )
+                    await asyncio.sleep(retry_after)
+                    last_error = RedditRateLimitError("Rate limited by Reddit API")
+                    continue
+
+                if response.status_code >= 500:
+                    # Server error - retry with backoff
+                    wait_time = 2**attempt
+                    logger.warning(
+                        f"Reddit API server error {response.status_code}, "
+                        f"retrying in {wait_time}s (attempt {attempt + 1}/{max_retries})"
+                    )
+                    await asyncio.sleep(wait_time)
+                    last_error = RedditAPIError(response.status_code, "Server error")
+                    continue
+
+                response.raise_for_status()
+                data = response.json()
+
+                # Parse results
+                results: list[SearchResult] = []
+                posts = data.get("data", {}).get("children", [])
+
+                for post in posts:
+                    post_data = post.get("data", {})
+
+                    # Skip removed/deleted posts
+                    if post_data.get("removed_by_category") or post_data.get("removed"):
+                        continue
+
+                    # Build snippet from selftext or title
+                    selftext = post_data.get("selftext", "")
+                    snippet = selftext[:500] if selftext else post_data.get("title", "")
+
+                    result = SearchResult(
+                        url=f"https://www.reddit.com{post_data.get('permalink', '')}",
+                        title=post_data.get("title", ""),
+                        snippet=snippet,
+                        source="reddit",
+                        published_at=_parse_created_utc(post_data.get("created_utc")),
+                        metadata={
+                            "subreddit": post_data.get("subreddit"),
+                            "author": post_data.get("author"),
+                            "score": post_data.get("score"),
+                            "num_comments": post_data.get("num_comments"),
+                            "is_self": post_data.get("is_self"),
+                            "domain": post_data.get("domain"),
+                        },
+                    )
+                    results.append(result)
+
+                logger.debug(f"Reddit search for '{query}' returned {len(results)} results")
+                return results
+
+        except httpx.HTTPStatusError as e:
+            last_error = RedditAPIError(
+                e.response.status_code,
+                e.response.text[:200] if e.response.text else "Unknown error",
+            )
+            # Don't retry client errors (4xx except 429 and 401)
+            if 400 <= e.response.status_code < 500 and e.response.status_code not in (
+                401,
+                429,
+            ):
+                raise last_error from e
+
+        except httpx.TimeoutException as e:
+            wait_time = 2**attempt
+            logger.warning(
+                f"Reddit API timeout, retrying in {wait_time}s "
+                f"(attempt {attempt + 1}/{max_retries})"
+            )
+            await asyncio.sleep(wait_time)
+            last_error = e
+
+        except httpx.RequestError as e:
+            wait_time = 2**attempt
+            logger.warning(
+                f"Reddit API request error: {e}, retrying in {wait_time}s "
+                f"(attempt {attempt + 1}/{max_retries})"
+            )
+            await asyncio.sleep(wait_time)
+            last_error = e
+
+    # All retries exhausted
+    if isinstance(last_error, RedditError):
+        raise last_error
+    raise RedditAPIError(0, f"Request failed after {max_retries} attempts: {last_error}")
+
+
+class RedditSource(DataSource):
+    """Reddit data source implementation."""
+
+    def __init__(self) -> None:
+        """Initialize the Reddit source."""
+        self._client: RedditClient | None = None
+
+    @property
+    def source_name(self) -> str:
+        """Return the source identifier."""
+        return "reddit"
+
+    def _get_client(self) -> RedditClient:
+        """Get or create the Reddit client."""
+        if self._client is None:
+            if not settings.reddit_client_id or not settings.reddit_client_secret:
+                raise RedditCredentialsMissingError(
+                    "REDDIT_CLIENT_ID and REDDIT_CLIENT_SECRET must be set"
+                )
+            self._client = RedditClient(
+                client_id=settings.reddit_client_id,
+                client_secret=settings.reddit_client_secret,
+                user_agent=settings.reddit_user_agent,
+            )
+        return self._client
+
+    async def search(
+        self,
+        query: str,
+        *,
+        count: int = 25,
+        **kwargs: object,
+    ) -> list[SearchResult]:
+        """Search Reddit for the given query.
+
+        Args:
+            query: The search query string.
+            count: Maximum number of results to return.
+            **kwargs: Additional parameters:
+                - subreddits: list[str] for specific subreddit search
+                - time_filter: TimeFilter for time-based filtering
+
+        Returns:
+            A list of SearchResult objects.
+        """
+        subreddits = kwargs.get("subreddits")
+        if subreddits is not None and not isinstance(subreddits, list):
+            subreddits = None
+
+        time_filter = kwargs.get("time_filter", "week")
+        if time_filter not in ("hour", "day", "week", "month", "year", "all"):
+            time_filter = "week"
+
+        return await search_reddit(
+            query,
+            subreddits=subreddits,  # type: ignore[arg-type]
+            time_filter=time_filter,  # type: ignore[arg-type]
+            count=count,
+            client=self._get_client(),
+        )
+
+    async def health_check(self) -> bool:
+        """Check if Reddit is configured and available."""
+        if not settings.reddit_client_id or not settings.reddit_client_secret:
+            return False
+
+        try:
+            client = self._get_client()
+            await client._get_token()
+            return True
+        except RedditError:
+            return False
+
+
+# Convenience instance
+reddit_source = RedditSource()

--- a/apps/api/tests/test_reddit.py
+++ b/apps/api/tests/test_reddit.py
@@ -1,0 +1,766 @@
+"""Tests for Reddit data source."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from wintern.sources.reddit import (
+    REDDIT_AUTH_URL,
+    REDDIT_SEARCH_URL,
+    REDDIT_SUBREDDIT_SEARCH_URL,
+    RedditAPIError,
+    RedditAuthError,
+    RedditClient,
+    RedditCredentialsMissingError,
+    RedditError,
+    RedditRateLimitError,
+    RedditSource,
+    _parse_created_utc,
+    search_reddit,
+)
+
+
+class TestParseCreatedUtc:
+    """Tests for _parse_created_utc helper."""
+
+    def test_parse_valid_timestamp(self) -> None:
+        """Test parsing a valid Unix timestamp."""
+        timestamp = 1704067200.0  # 2024-01-01 00:00:00 UTC
+        result = _parse_created_utc(timestamp)
+
+        assert result is not None
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 1
+        assert result.tzinfo == UTC
+
+    def test_parse_none(self) -> None:
+        """Test parsing None returns None."""
+        assert _parse_created_utc(None) is None
+
+    def test_parse_invalid_timestamp(self) -> None:
+        """Test parsing invalid timestamp returns None."""
+        # Timestamp too large
+        result = _parse_created_utc(float("inf"))
+        assert result is None
+
+
+class TestRedditClient:
+    """Tests for RedditClient class."""
+
+    def test_init(self) -> None:
+        """Test client initialization."""
+        client = RedditClient(
+            client_id="test_id",
+            client_secret="test_secret",
+            user_agent="test_agent",
+        )
+
+        assert client.client_id == "test_id"
+        assert client.client_secret == "test_secret"
+        assert client.user_agent == "test_agent"
+        assert client._token is None
+        assert client._token_expires is None
+
+    @pytest.mark.asyncio
+    async def test_get_token_success(self) -> None:
+        """Test successful token retrieval."""
+        client = RedditClient(
+            client_id="test_id",
+            client_secret="test_secret",
+            user_agent="test_agent",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            token = await client._get_token()
+
+            assert token == "test_token"
+            assert client._token == "test_token"
+            assert client._token_expires is not None
+
+    @pytest.mark.asyncio
+    async def test_get_token_uses_cache(self) -> None:
+        """Test that cached token is returned when valid."""
+        client = RedditClient(
+            client_id="test_id",
+            client_secret="test_secret",
+            user_agent="test_agent",
+        )
+
+        # Set up cached token
+        client._token = "cached_token"
+        client._token_expires = datetime.now(UTC) + timedelta(hours=1)
+
+        # Should return cached token without making request
+        token = await client._get_token()
+        assert token == "cached_token"
+
+    @pytest.mark.asyncio
+    async def test_get_token_refreshes_expired(self) -> None:
+        """Test that expired token triggers refresh."""
+        client = RedditClient(
+            client_id="test_id",
+            client_secret="test_secret",
+            user_agent="test_agent",
+        )
+
+        # Set up expired token
+        client._token = "old_token"
+        client._token_expires = datetime.now(UTC) - timedelta(hours=1)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_token",
+            "expires_in": 3600,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            token = await client._get_token()
+            assert token == "new_token"
+
+    @pytest.mark.asyncio
+    async def test_get_token_auth_failure(self) -> None:
+        """Test authentication failure."""
+        client = RedditClient(
+            client_id="bad_id",
+            client_secret="bad_secret",
+            user_agent="test_agent",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(RedditAuthError, match="Invalid Reddit credentials"):
+                await client._get_token()
+
+    def test_clear_token(self) -> None:
+        """Test clearing the cached token."""
+        client = RedditClient(
+            client_id="test_id",
+            client_secret="test_secret",
+            user_agent="test_agent",
+        )
+
+        client._token = "test_token"
+        client._token_expires = datetime.now(UTC) + timedelta(hours=1)
+
+        client.clear_token()
+
+        assert client._token is None
+        assert client._token_expires is None
+
+
+class TestSearchReddit:
+    """Tests for search_reddit function."""
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials(self) -> None:
+        """Test error when credentials are missing."""
+        with patch("wintern.sources.reddit.settings") as mock_settings:
+            mock_settings.reddit_client_id = ""
+            mock_settings.reddit_client_secret = ""
+
+            with pytest.raises(
+                RedditCredentialsMissingError,
+                match="REDDIT_CLIENT_ID and REDDIT_CLIENT_SECRET",
+            ):
+                await search_reddit("test query")
+
+    @pytest.mark.asyncio
+    async def test_successful_search(self) -> None:
+        """Test successful search returns results."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_search_response = MagicMock()
+        mock_search_response.status_code = 200
+        mock_search_response.json.return_value = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "title": "Test Post",
+                            "selftext": "Test content here",
+                            "permalink": "/r/test/comments/abc123/test_post/",
+                            "subreddit": "test",
+                            "author": "testuser",
+                            "score": 100,
+                            "num_comments": 50,
+                            "is_self": True,
+                            "domain": "self.test",
+                            "created_utc": 1704067200.0,
+                        }
+                    }
+                ]
+            }
+        }
+        mock_search_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(return_value=mock_search_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test query")
+
+            assert len(results) == 1
+            assert results[0].title == "Test Post"
+            assert results[0].snippet == "Test content here"
+            assert results[0].source == "reddit"
+            assert "subreddit" in results[0].metadata
+            assert results[0].metadata["subreddit"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_search_with_subreddits(self) -> None:
+        """Test search within specific subreddits."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_search_response = MagicMock()
+        mock_search_response.status_code = 200
+        mock_search_response.json.return_value = {"data": {"children": []}}
+        mock_search_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(return_value=mock_search_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            await search_reddit("test", subreddits=["python", "programming"])
+
+            # Verify correct URL was used
+            call_args = mock_client.get.call_args
+            url = call_args[1].get("url") or call_args[0][0]
+            assert "python+programming" in url
+
+    @pytest.mark.asyncio
+    async def test_search_skips_removed_posts(self) -> None:
+        """Test that removed posts are skipped."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_search_response = MagicMock()
+        mock_search_response.status_code = 200
+        mock_search_response.json.return_value = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "title": "Removed Post",
+                            "selftext": "",
+                            "permalink": "/r/test/comments/abc123/",
+                            "removed_by_category": "moderator",
+                        }
+                    },
+                    {
+                        "data": {
+                            "title": "Valid Post",
+                            "selftext": "Content",
+                            "permalink": "/r/test/comments/def456/",
+                        }
+                    },
+                ]
+            }
+        }
+        mock_search_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(return_value=mock_search_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test")
+
+            assert len(results) == 1
+            assert results[0].title == "Valid Post"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_handling(self) -> None:
+        """Test handling of rate limit responses."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_rate_limit_response = MagicMock()
+        mock_rate_limit_response.status_code = 429
+        mock_rate_limit_response.headers = {"Retry-After": "1"}
+
+        mock_success_response = MagicMock()
+        mock_success_response.status_code = 200
+        mock_success_response.json.return_value = {"data": {"children": []}}
+        mock_success_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("wintern.sources.reddit.asyncio.sleep", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(
+                side_effect=[mock_rate_limit_response, mock_success_response]
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test", max_retries=2)
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_server_error_retry(self) -> None:
+        """Test retry on server errors."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_error_response = MagicMock()
+        mock_error_response.status_code = 500
+
+        mock_success_response = MagicMock()
+        mock_success_response.status_code = 200
+        mock_success_response.json.return_value = {"data": {"children": []}}
+        mock_success_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("wintern.sources.reddit.asyncio.sleep", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(side_effect=[mock_error_response, mock_success_response])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test", max_retries=2)
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_token_refresh_on_401(self) -> None:
+        """Test token refresh when 401 received during search."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "new_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_401_response = MagicMock()
+        mock_401_response.status_code = 401
+
+        mock_success_response = MagicMock()
+        mock_success_response.status_code = 200
+        mock_success_response.json.return_value = {"data": {"children": []}}
+        mock_success_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(side_effect=[mock_401_response, mock_success_response])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test", max_retries=2)
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_count_clamping(self) -> None:
+        """Test that count is clamped to valid range."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_search_response = MagicMock()
+        mock_search_response.status_code = 200
+        mock_search_response.json.return_value = {"data": {"children": []}}
+        mock_search_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(return_value=mock_search_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            # Test count > 100
+            await search_reddit("test", count=200)
+            call_args = mock_client.get.call_args
+            params = call_args[1]["params"]
+            assert params["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_retry(self) -> None:
+        """Test retry on timeout errors."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_success_response = MagicMock()
+        mock_success_response.status_code = 200
+        mock_success_response.json.return_value = {"data": {"children": []}}
+        mock_success_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("wintern.sources.reddit.asyncio.sleep", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(
+                side_effect=[httpx.TimeoutException("Timeout"), mock_success_response]
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            results = await search_reddit("test", max_retries=2)
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted(self) -> None:
+        """Test error raised when retries are exhausted."""
+        mock_auth_response = MagicMock()
+        mock_auth_response.status_code = 200
+        mock_auth_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_auth_response.raise_for_status = MagicMock()
+
+        mock_error_response = MagicMock()
+        mock_error_response.status_code = 500
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("wintern.sources.reddit._rate_limit", new_callable=AsyncMock),
+            patch("wintern.sources.reddit.asyncio.sleep", new_callable=AsyncMock),
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_auth_response)
+            mock_client.get = AsyncMock(return_value=mock_error_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            with pytest.raises(RedditAPIError, match="Server error"):
+                await search_reddit("test", max_retries=2)
+
+
+class TestRedditSource:
+    """Tests for RedditSource class."""
+
+    def test_source_name(self) -> None:
+        """Test source name property."""
+        source = RedditSource()
+        assert source.source_name == "reddit"
+
+    @pytest.mark.asyncio
+    async def test_search_delegates_to_search_reddit(self) -> None:
+        """Test that search method delegates to search_reddit."""
+        source = RedditSource()
+
+        with patch("wintern.sources.reddit.search_reddit") as mock_search:
+            mock_search.return_value = []
+
+            with patch("wintern.sources.reddit.settings") as mock_settings:
+                mock_settings.reddit_client_id = "test_id"
+                mock_settings.reddit_client_secret = "test_secret"
+                mock_settings.reddit_user_agent = "test_agent"
+
+                await source.search("test query", count=10)
+
+                mock_search.assert_called_once()
+                call_kwargs = mock_search.call_args[1]
+                assert call_kwargs["count"] == 10
+
+    @pytest.mark.asyncio
+    async def test_search_with_time_filter(self) -> None:
+        """Test search with time filter parameter."""
+        source = RedditSource()
+
+        with patch("wintern.sources.reddit.search_reddit") as mock_search:
+            mock_search.return_value = []
+
+            with patch("wintern.sources.reddit.settings") as mock_settings:
+                mock_settings.reddit_client_id = "test_id"
+                mock_settings.reddit_client_secret = "test_secret"
+                mock_settings.reddit_user_agent = "test_agent"
+
+                await source.search("test", time_filter="month")
+
+                call_kwargs = mock_search.call_args[1]
+                assert call_kwargs["time_filter"] == "month"
+
+    @pytest.mark.asyncio
+    async def test_search_with_invalid_time_filter(self) -> None:
+        """Test search with invalid time filter defaults to week."""
+        source = RedditSource()
+
+        with patch("wintern.sources.reddit.search_reddit") as mock_search:
+            mock_search.return_value = []
+
+            with patch("wintern.sources.reddit.settings") as mock_settings:
+                mock_settings.reddit_client_id = "test_id"
+                mock_settings.reddit_client_secret = "test_secret"
+                mock_settings.reddit_user_agent = "test_agent"
+
+                await source.search("test", time_filter="invalid")
+
+                call_kwargs = mock_search.call_args[1]
+                assert call_kwargs["time_filter"] == "week"
+
+    @pytest.mark.asyncio
+    async def test_search_with_subreddits(self) -> None:
+        """Test search with subreddits parameter."""
+        source = RedditSource()
+
+        with patch("wintern.sources.reddit.search_reddit") as mock_search:
+            mock_search.return_value = []
+
+            with patch("wintern.sources.reddit.settings") as mock_settings:
+                mock_settings.reddit_client_id = "test_id"
+                mock_settings.reddit_client_secret = "test_secret"
+                mock_settings.reddit_user_agent = "test_agent"
+
+                await source.search("test", subreddits=["python", "programming"])
+
+                call_kwargs = mock_search.call_args[1]
+                assert call_kwargs["subreddits"] == ["python", "programming"]
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self) -> None:
+        """Test health check when credentials are valid."""
+        source = RedditSource()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "test_id"
+            mock_settings.reddit_client_secret = "test_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await source.health_check()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_missing_credentials(self) -> None:
+        """Test health check when credentials are missing."""
+        source = RedditSource()
+
+        with patch("wintern.sources.reddit.settings") as mock_settings:
+            mock_settings.reddit_client_id = ""
+            mock_settings.reddit_client_secret = ""
+
+            result = await source.health_check()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_health_check_auth_failure(self) -> None:
+        """Test health check when authentication fails."""
+        source = RedditSource()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+
+        with (
+            patch("wintern.sources.reddit.settings") as mock_settings,
+            patch("httpx.AsyncClient") as mock_client_class,
+        ):
+            mock_settings.reddit_client_id = "bad_id"
+            mock_settings.reddit_client_secret = "bad_secret"
+            mock_settings.reddit_user_agent = "test_agent"
+
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await source.health_check()
+            assert result is False
+
+
+class TestExceptionHierarchy:
+    """Tests for exception class hierarchy."""
+
+    def test_reddit_error_is_base(self) -> None:
+        """Test RedditError is the base exception."""
+        assert issubclass(RedditCredentialsMissingError, RedditError)
+        assert issubclass(RedditAuthError, RedditError)
+        assert issubclass(RedditRateLimitError, RedditError)
+        assert issubclass(RedditAPIError, RedditError)
+
+    def test_reddit_api_error_has_status_code(self) -> None:
+        """Test RedditAPIError includes status code."""
+        error = RedditAPIError(503, "Service unavailable")
+        assert error.status_code == 503
+        assert "503" in str(error)
+        assert "Service unavailable" in str(error)
+
+
+class TestUrlConstants:
+    """Tests for URL constants."""
+
+    def test_auth_url(self) -> None:
+        """Test auth URL is correct."""
+        assert REDDIT_AUTH_URL == "https://www.reddit.com/api/v1/access_token"
+
+    def test_search_url(self) -> None:
+        """Test search URL is correct."""
+        assert REDDIT_SEARCH_URL == "https://oauth.reddit.com/search"
+
+    def test_subreddit_search_url(self) -> None:
+        """Test subreddit search URL template is correct."""
+        assert REDDIT_SUBREDDIT_SEARCH_URL == "https://oauth.reddit.com/r/{subreddit}/search"


### PR DESCRIPTION
## Summary
- Add Reddit API integration with OAuth2 authentication and token caching
- Implement rate limiting (60 requests/minute to stay within Reddit API limits)
- Support searching across all Reddit or specific subreddits with time filters (hour, day, week, month, year, all)
- Follow same patterns as Brave Search integration (DataSource base class, SearchResult schema)

## Test plan
- [x] 32 unit tests covering:
  - OAuth2 token management (caching, refresh, expiry)
  - Search functionality with various parameters
  - Error handling (auth failures, rate limits, server errors)
  - RedditSource class methods
  - Exception hierarchy
- [x] Type checking with pyright passes
- [x] All 169 tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)