### PR TITLE
fix: standardize API route prefixes to /v1/winterns

### DIFF
--- a/apps/api/src/wintern/execution/router.py
+++ b/apps/api/src/wintern/execution/router.py
@@ -24,7 +24,7 @@ from wintern.winterns import service as wintern_service
 
 log = structlog.get_logger()
 
-router = APIRouter(prefix="/api/v1/winterns", tags=["execution"])
+router = APIRouter(prefix="/v1/winterns", tags=["execution"])
 
 AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_session)]
 CurrentUserDep = Annotated[User, Depends(current_user)]
@@ -82,7 +82,7 @@ async def trigger_run(
     This endpoint immediately creates a run record and schedules the
     actual execution in the background, returning 202 Accepted.
 
-    The run can be monitored using GET /api/v1/winterns/{id}/runs/{run_id}.
+    The run can be monitored using GET /v1/winterns/{id}/runs/{run_id}.
     """
     # Verify wintern exists and belongs to user
     wintern = await wintern_service.get_wintern_by_id(session, wintern_id, user.id)

--- a/apps/api/src/wintern/winterns/router.py
+++ b/apps/api/src/wintern/winterns/router.py
@@ -17,7 +17,7 @@ from wintern.winterns.schemas import (
     WinternUpdate,
 )
 
-router = APIRouter(prefix="/api/v1/winterns", tags=["winterns"])
+router = APIRouter(prefix="/v1/winterns", tags=["winterns"])
 
 AsyncSessionDep = Annotated[AsyncSession, Depends(get_async_session)]
 CurrentUserDep = Annotated[User, Depends(current_user)]

--- a/apps/api/tests/test_execution_integration.py
+++ b/apps/api/tests/test_execution_integration.py
@@ -26,7 +26,7 @@ async def create_wintern_with_configs(
 ) -> dict:
     """Helper to create a wintern with source and delivery configs."""
     response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": name,
@@ -51,7 +51,7 @@ async def create_wintern_with_configs(
 
 
 class TestTriggerRunEndpoint:
-    """Tests for POST /api/v1/winterns/{id}/run endpoint."""
+    """Tests for POST /v1/winterns/{id}/run endpoint."""
 
     @pytest.mark.asyncio
     async def test_trigger_run_success(self, client: AsyncClient):
@@ -60,7 +60,7 @@ class TestTriggerRunEndpoint:
         wintern = await create_wintern_with_configs(client, token)
 
         response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -76,7 +76,7 @@ class TestTriggerRunEndpoint:
         fake_id = str(uuid.uuid4())
 
         response = await client.post(
-            f"/api/v1/winterns/{fake_id}/run",
+            f"/v1/winterns/{fake_id}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -89,7 +89,7 @@ class TestTriggerRunEndpoint:
 
         # Create wintern without sources
         response = await client.post(
-            "/api/v1/winterns",
+            "/v1/winterns",
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "name": "No Sources Wintern",
@@ -102,7 +102,7 @@ class TestTriggerRunEndpoint:
         wintern = response.json()
 
         response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -116,7 +116,7 @@ class TestTriggerRunEndpoint:
 
         # Create wintern without delivery configs
         response = await client.post(
-            "/api/v1/winterns",
+            "/v1/winterns",
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "name": "No Delivery Wintern",
@@ -129,7 +129,7 @@ class TestTriggerRunEndpoint:
         wintern = response.json()
 
         response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -141,7 +141,7 @@ class TestTriggerRunEndpoint:
         """Should return 401 for unauthenticated request."""
         fake_id = str(uuid.uuid4())
 
-        response = await client.post(f"/api/v1/winterns/{fake_id}/run")
+        response = await client.post(f"/v1/winterns/{fake_id}/run")
 
         assert response.status_code == 401
 
@@ -155,7 +155,7 @@ class TestTriggerRunEndpoint:
         # Try to trigger as user 2
         token2 = await get_auth_token(client, "trigger-user2@example.com")
         response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token2}"},
         )
 
@@ -163,7 +163,7 @@ class TestTriggerRunEndpoint:
 
 
 class TestListRunsEndpoint:
-    """Tests for GET /api/v1/winterns/{id}/runs endpoint."""
+    """Tests for GET /v1/winterns/{id}/runs endpoint."""
 
     @pytest.mark.asyncio
     async def test_list_runs_empty(self, client: AsyncClient):
@@ -172,7 +172,7 @@ class TestListRunsEndpoint:
         wintern = await create_wintern_with_configs(client, token)
 
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs",
+            f"/v1/winterns/{wintern['id']}/runs",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -189,7 +189,7 @@ class TestListRunsEndpoint:
 
         # List runs (empty is fine, we're testing structure)
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs",
+            f"/v1/winterns/{wintern['id']}/runs",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -209,7 +209,7 @@ class TestListRunsEndpoint:
 
         # Get with specific pagination params
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs?skip=5&limit=10",
+            f"/v1/winterns/{wintern['id']}/runs?skip=5&limit=10",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -225,7 +225,7 @@ class TestListRunsEndpoint:
         fake_id = str(uuid.uuid4())
 
         response = await client.get(
-            f"/api/v1/winterns/{fake_id}/runs",
+            f"/v1/winterns/{fake_id}/runs",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -236,13 +236,13 @@ class TestListRunsEndpoint:
         """Should return 401 for unauthenticated request."""
         fake_id = str(uuid.uuid4())
 
-        response = await client.get(f"/api/v1/winterns/{fake_id}/runs")
+        response = await client.get(f"/v1/winterns/{fake_id}/runs")
 
         assert response.status_code == 401
 
 
 class TestGetRunEndpoint:
-    """Tests for GET /api/v1/winterns/{id}/runs/{run_id} endpoint."""
+    """Tests for GET /v1/winterns/{id}/runs/{run_id} endpoint."""
 
     @pytest.mark.asyncio
     async def test_trigger_returns_correct_response_fields(self, client: AsyncClient):
@@ -252,7 +252,7 @@ class TestGetRunEndpoint:
 
         # Trigger a run - the trigger response includes wintern_id and message
         trigger_response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
         trigger_data = trigger_response.json()
@@ -271,7 +271,7 @@ class TestGetRunEndpoint:
         fake_run_id = str(uuid.uuid4())
 
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs/{fake_run_id}",
+            f"/v1/winterns/{wintern['id']}/runs/{fake_run_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -285,7 +285,7 @@ class TestGetRunEndpoint:
         fake_run_id = str(uuid.uuid4())
 
         response = await client.get(
-            f"/api/v1/winterns/{fake_wintern_id}/runs/{fake_run_id}",
+            f"/v1/winterns/{fake_wintern_id}/runs/{fake_run_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -304,7 +304,7 @@ class TestGetRunEndpoint:
 
         # Try to get a non-existent run
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs/{fake_run_id}",
+            f"/v1/winterns/{wintern['id']}/runs/{fake_run_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -316,7 +316,7 @@ class TestGetRunEndpoint:
         fake_wintern_id = str(uuid.uuid4())
         fake_run_id = str(uuid.uuid4())
 
-        response = await client.get(f"/api/v1/winterns/{fake_wintern_id}/runs/{fake_run_id}")
+        response = await client.get(f"/v1/winterns/{fake_wintern_id}/runs/{fake_run_id}")
 
         assert response.status_code == 401
 
@@ -331,7 +331,7 @@ class TestRunResponseSchema:
         wintern = await create_wintern_with_configs(client, token)
 
         response = await client.post(
-            f"/api/v1/winterns/{wintern['id']}/run",
+            f"/v1/winterns/{wintern['id']}/run",
             headers={"Authorization": f"Bearer {token}"},
         )
 
@@ -354,7 +354,7 @@ class TestRunResponseSchema:
         wintern = await create_wintern_with_configs(client, token)
 
         response = await client.get(
-            f"/api/v1/winterns/{wintern['id']}/runs",
+            f"/v1/winterns/{wintern['id']}/runs",
             headers={"Authorization": f"Bearer {token}"},
         )
 

--- a/apps/api/tests/test_winterns.py
+++ b/apps/api/tests/test_winterns.py
@@ -23,7 +23,7 @@ async def test_list_winterns_empty(client: AsyncClient):
     token = await get_auth_token(client, "list-empty@example.com")
 
     response = await client.get(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
@@ -43,7 +43,7 @@ async def test_create_wintern(client: AsyncClient):
     token = await get_auth_token(client, "create@example.com")
 
     response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "AI News Digest",
@@ -81,7 +81,7 @@ async def test_create_wintern_minimal(client: AsyncClient):
     token = await get_auth_token(client, "minimal@example.com")
 
     response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Simple Wintern",
@@ -102,7 +102,7 @@ async def test_get_wintern(client: AsyncClient):
 
     # Create a wintern first
     create_response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Test Wintern",
@@ -113,7 +113,7 @@ async def test_get_wintern(client: AsyncClient):
 
     # Get the wintern
     response = await client.get(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
@@ -128,7 +128,7 @@ async def test_get_wintern_not_found(client: AsyncClient):
     token = await get_auth_token(client, "notfound@example.com")
 
     response = await client.get(
-        "/api/v1/winterns/00000000-0000-0000-0000-000000000000",
+        "/v1/winterns/00000000-0000-0000-0000-000000000000",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 404
@@ -140,7 +140,7 @@ async def test_get_wintern_other_user(client: AsyncClient):
     # Create wintern as user 1
     token1 = await get_auth_token(client, "user1@example.com")
     create_response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token1}"},
         json={
             "name": "User 1 Wintern",
@@ -152,7 +152,7 @@ async def test_get_wintern_other_user(client: AsyncClient):
     # Try to access as user 2
     token2 = await get_auth_token(client, "user2@example.com")
     response = await client.get(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token2}"},
     )
     assert response.status_code == 404
@@ -165,7 +165,7 @@ async def test_update_wintern(client: AsyncClient):
 
     # Create a wintern
     create_response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Original Name",
@@ -176,7 +176,7 @@ async def test_update_wintern(client: AsyncClient):
 
     # Update the wintern
     response = await client.put(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Updated Name",
@@ -197,7 +197,7 @@ async def test_update_wintern_preserves_next_run_at(client: AsyncClient):
 
     # Create a scheduled wintern
     create_response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Scheduled Wintern",
@@ -212,7 +212,7 @@ async def test_update_wintern_preserves_next_run_at(client: AsyncClient):
 
     # Update only name/description - should NOT affect next_run_at
     response = await client.put(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Renamed Wintern",
@@ -232,7 +232,7 @@ async def test_delete_wintern(client: AsyncClient):
 
     # Create a wintern
     create_response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "To Delete",
@@ -243,14 +243,14 @@ async def test_delete_wintern(client: AsyncClient):
 
     # Delete the wintern
     response = await client.delete(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 204
 
     # Verify it's soft deleted (still accessible but is_active=False)
     get_response = await client.get(
-        f"/api/v1/winterns/{wintern_id}",
+        f"/v1/winterns/{wintern_id}",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert get_response.status_code == 200
@@ -265,7 +265,7 @@ async def test_list_winterns_pagination(client: AsyncClient):
     # Create 5 winterns
     for i in range(5):
         await client.post(
-            "/api/v1/winterns",
+            "/v1/winterns",
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "name": f"Wintern {i}",
@@ -275,7 +275,7 @@ async def test_list_winterns_pagination(client: AsyncClient):
 
     # Get first page
     response = await client.get(
-        "/api/v1/winterns?skip=0&limit=2",
+        "/v1/winterns?skip=0&limit=2",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
@@ -287,7 +287,7 @@ async def test_list_winterns_pagination(client: AsyncClient):
 
     # Get second page
     response = await client.get(
-        "/api/v1/winterns?skip=2&limit=2",
+        "/v1/winterns?skip=2&limit=2",
         headers={"Authorization": f"Bearer {token}"},
     )
     data = response.json()
@@ -303,7 +303,7 @@ async def test_list_winterns_aggregate_counts(client: AsyncClient):
     # Create 2 active winterns with schedules (will have next_run_at set)
     for i in range(2):
         await client.post(
-            "/api/v1/winterns",
+            "/v1/winterns",
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "name": f"Active Scheduled {i}",
@@ -314,7 +314,7 @@ async def test_list_winterns_aggregate_counts(client: AsyncClient):
 
     # Create 1 active wintern without schedule
     await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         headers={"Authorization": f"Bearer {token}"},
         json={
             "name": "Active No Schedule",
@@ -325,7 +325,7 @@ async def test_list_winterns_aggregate_counts(client: AsyncClient):
     # Create 2 winterns with schedules and pause them (next_run_at should be cleared)
     for i in range(2):
         create_response = await client.post(
-            "/api/v1/winterns",
+            "/v1/winterns",
             headers={"Authorization": f"Bearer {token}"},
             json={
                 "name": f"To Pause {i}",
@@ -336,14 +336,14 @@ async def test_list_winterns_aggregate_counts(client: AsyncClient):
         wintern_id = create_response.json()["id"]
         # Pause by setting is_active=False - should clear next_run_at
         await client.put(
-            f"/api/v1/winterns/{wintern_id}",
+            f"/v1/winterns/{wintern_id}",
             headers={"Authorization": f"Bearer {token}"},
             json={"is_active": False},
         )
 
     # List winterns with small page size to test counts are across all, not just page
     response = await client.get(
-        "/api/v1/winterns?limit=2",
+        "/v1/winterns?limit=2",
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 200
@@ -363,11 +363,11 @@ async def test_list_winterns_aggregate_counts(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_winterns_unauthorized(client: AsyncClient):
     """Test that unauthenticated requests are rejected."""
-    response = await client.get("/api/v1/winterns")
+    response = await client.get("/v1/winterns")
     assert response.status_code == 401
 
     response = await client.post(
-        "/api/v1/winterns",
+        "/v1/winterns",
         json={"name": "Test", "context": "Test"},
     )
     assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Changed router prefixes from `/api/v1/winterns` to `/v1/winterns` in both winterns and execution routers
- Updated all test files to use the new paths
- Fixed docstring reference in execution router

## Context
The Vite dev proxy strips `/api` from frontend requests before forwarding to the backend, but the routers were using `/api/v1/winterns` as their prefix, causing 404 errors.

Closes #68

## Test plan
- [x] Linting passes (`ruff check .`)
- [x] All 290 tests pass (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)